### PR TITLE
fix: update PR template link to match GitHub organization name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 Thank you for your pull request. Please provide a description above and review
 the requirements below.
 
-Contributors guide: https://github.com/web3community/devprotocol.xyz/blob/main/CONTRIBUTING.md
+Contributors guide: https://github.com/community-builders/community-builders.github-io/blob/main/CONTRIBUTING.md
 -->
 
 <!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->
@@ -18,7 +18,7 @@ Contributors guide: https://github.com/web3community/devprotocol.xyz/blob/main/C
 **I agree to the following :-**
 
 * [ ]   Added description of the change
-* [ ]   I've read the [contributing guidelines](https://github.com/web3community/devprotocol.xyz/blob/main/CONTRIBUTING.md)
+* [ ]   I've read the [contributing guidelines](https://github.com/community-builders/community-builders.github-io/blob/main/CONTRIBUTING.md)
 * [ ]   Search previous suggestions before making a new PR, as yours may be a duplicate.
 * [ ]   I acknowledge that all my contributions will be made under the project's license.
 


### PR DESCRIPTION
#### Description of the change

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/community-builders/community-builders.github.io/blob/main/CONTRIBUTING.md
-->

- Update PR template link to match the GitHub organization name.
  - The PR template was using `web3community` links. We should use `community-builders` instead.

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

#### Checklist

**I agree to the following :-**

* [x]   Added description of the change
* [x]   I've read the [contributing guidelines](https://github.com/community-builders/community-builders.github.io/blob/main/CONTRIBUTING.md)
* [x]   Search previous suggestions before making a new PR, as yours may be a duplicate.
* [x]   I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->
